### PR TITLE
feat: set contextual search to false

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -175,7 +175,13 @@ module.exports = {
         appId: "Y38E5PBP7U",
         apiKey: "d53ab77e8cc34e860d226276347bddb7",
         indexName: "code-inspector",
-        algoliaOptions: {},
+        /**
+         * keep contextual search as false otherwise search will fail
+         * see link for reference.
+         *
+         * https://discourse.algolia.com/t/algolia-searchbar-is-not-working-with-docusaurus-v2/14659/2
+         */
+        contextualSearch: false,
       },
     }),
 };


### PR DESCRIPTION
avoid contextual search as it adds some facet filters assuming a template that breaks the search. until we require contextual search we'll disable it